### PR TITLE
更正pip安装mysql-connector-python步骤

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Web
 
 ```
 apt-get install python-dev
-pip install tornado u-msgpack-python jinja2 chardet requests mysql-connector-python redis pbkdf2 pycrypto
+pip install tornado u-msgpack-python jinja2 chardet requests redis pbkdf2 pycrypto
+pip install mysql-connector-python --allow-external mysql-connector-python
 ./web.py
 ```
 


### PR DESCRIPTION
pip安装mysql-connector-python需要 --allow-external参数
测试环境:
1. python2.7.9 ubuntu14.04 pip 6.0.6
2. python2.7.5 fedora20 pip1.5.6
